### PR TITLE
prefer update-to instead of update

### DIFF
--- a/package/helperscripts/yumHandler.sh
+++ b/package/helperscripts/yumHandler.sh
@@ -88,7 +88,7 @@ do
         update_str="$update_str $element"
 done
 if [ ! -z "$update_str" ]; then
-	yum -y --enablerepo=$REPO update $update_str &>log/yumError.log
+	yum -y --enablerepo=$REPO update-to $update_str &>log/yumError.log
 	grepecho "UPDATE"
 fi
 


### PR DESCRIPTION
We are currently using the cloudconductor setup for one of our products. However, we faced the issue that the agent was trying to update the same package with the same version twice (we are on version 2.x currently and looks like the processing of the yum list installed result on this branch might be causing the issue).

The result of the issue was that the same yum update command was issued twice:
```
yum update nginx-1.16.1
```
and in the next schedule again:
```
yum update nginx-1.16.1
```

In yum, issuing the same update command, with a specific version, leads to the package being updated to its latest repo version. This was a big issue for us and guess it might be for others as well. Besides this, I think the expected behaviour here would be that you can rely on the cloudconductor agent to install the requested version and not accidentally installing the newest one.

The behaviour that I described can also be found in the documentation of yum (http://man7.org/linux/man-pages/man8/yum.8.html):

> Note that "update" works on installed packages first, and only
              if there are no matches does it look for available packages.
              The difference is most noticeable when you do "update foo-1-2"
              which will act exactly as "update foo" if foo-1-2 is
              installed. You can use the "update-to" if you'd prefer that
              nothing happen in the above case.